### PR TITLE
新增投诉回调验签，修复商户微信交易配置查询结果字段

### DIFF
--- a/func_complaint.go
+++ b/func_complaint.go
@@ -1,0 +1,38 @@
+package dinpay
+
+import (
+	"bytes"
+	"errors"
+	"github.com/bytedance/sonic"
+	"io"
+	"net/http"
+)
+
+// ComplaintNotifyVerify 投诉内容回调验签
+func (t *Client) ComplaintNotifyVerify(httpBody []byte) (notifyReq *ComplaintNotifyReq, err error) {
+	reqReq := http.Request{Method: "POST", Body: io.NopCloser(bytes.NewBuffer(httpBody)), Header: http.Header{}}
+	reqReq.Header.Set(`Content-Type`, `application/x-www-form-urlencoded`)
+	if err = reqReq.ParseForm(); err != nil {
+		return nil, err
+	}
+	if !t.SM3WithSM2Verify([]byte(reqReq.Form.Get("data")), reqReq.Form.Get("sign")) {
+		return nil, errors.New("投诉内容验签失败")
+	}
+	httpBodyMap := make(map[string]string, len(reqReq.Form))
+	for key, strings := range reqReq.Form {
+		httpBodyMap[key] = strings[0]
+	}
+	httpBody, err = sonic.Marshal(httpBodyMap)
+	if err != nil {
+		return nil, err
+	}
+
+	var baseRes *NotifyReq[string]
+	if err = sonic.Unmarshal(httpBody, &baseRes); err != nil {
+		return nil, err
+	}
+	if notifyReq, err = ParseNotifyReq[ComplaintNotifyReqBody](baseRes); err != nil {
+		return nil, err
+	}
+	return
+}

--- a/model_complaint.go
+++ b/model_complaint.go
@@ -1,0 +1,30 @@
+package dinpay
+
+import "time"
+
+type ComplaintNotifyReqBody struct {
+	MerchantId         string    `json:"merchantId"`                  // 商户编号,支付系统分配的商户号
+	ComplaintId        string    `json:"complaintId"`                 // 投诉单号
+	OrderNo            string    `json:"orderNo"`                     // 商户订单号
+	ComplaintState     string    `json:"complaintState"`              // 投诉单状态
+	ProblemType        string    `json:"problemType,omitempty"`       // 问题类型
+	ProblemDescription string    `json:"problemDescription"`          //问题描述
+	ComplaintDetail    string    `json:"complaintDetail"`             //投诉详情
+	UserTagList        string    `json:"userTagList"`                 //用户标签
+	ComplaintDate      time.Time `json:"complaintDate"`               //时间格式：yyyy-MM-dd HH:mm:ss
+	ImgFileId          string    `json:"imgFileId,omitempty"`         //用户投诉图片id json数组USER_COMPLAINT_IMAGE:用户投诉图片;OPERATION_IMAGE:操作流水图片
+	ReplyState         string    `json:"replyState"`                  //回复状态
+	ErrorMsg           string    `json:"errorMsg,omitempty"`          //错误信息
+	NotifyId           string    `json:"notifyId,omitempty"`          //通知报文id
+	Amount             float64   `json:"amount,omitempty"`            //投诉订单金额
+	PayerPhone         string    `json:"payerPhone,omitempty"`        //投诉人联系方式
+	ComplaintTimes     int64     `json:"complaintTimes,omitempty"`    //用户投诉次数
+	AppPayType         string    `json:"appPayType,omitempty"`        //投诉单类型 WXPAY ALIPAY
+	ComplainUrl        string    `json:"complainUrl,omitempty"`       //投诉网址,支付宝特有参数
+	ProcessDate        string    `json:"processDate,omitempty"`       //处理时间
+	ProcessCode        string    `json:"processCode,omitempty"`       //商家处理结果码
+	ProcessRemark      string    `json:"processRemark,omitempty"`     //商家处理备注
+	ProcessImgUrlList  string    `json:"processImgUrlList,omitempty"` //商家处理备注图片url列表
+}
+
+type ComplaintNotifyReq = NotifyReq[ComplaintNotifyReqBody]

--- a/model_merchant_report.go
+++ b/model_merchant_report.go
@@ -122,7 +122,7 @@ type MerchantWxPublicApplyQueryRes struct {
 }
 
 type MerchantWxPublicApplyUpstreamDataItem struct {
-	ReportId          string   `json:"reportId,omitempty"`          // 报备ID
+	ReportId          int64    `json:"reportId,omitempty"`          // 报备ID
 	ChannelId         string   `json:"channelId,omitempty"`         // 渠道
 	UpstreamNo        string   `json:"upstreamNo,omitempty"`        // 上游商户号
 	AppIds            []string `json:"appIds,omitempty"`            // 支付公众号


### PR DESCRIPTION
1. 新增用户投诉订单的结果的验签方法
2. 修复商户微信交易配置查询结果里的 MerchantWxPublicApplyUpstreamDataItem 的 ReportId 属性类型为int64